### PR TITLE
Ignore folders for eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,5 +57,6 @@ module.exports = {
                 paths: ['src']
             }
         }
-    }
+    },
+    ignorePatterns: ['node_modules/', 'build/', 'dist/', 'third-party-packages']
 };


### PR DESCRIPTION
No need to lint the built files or `node_modules`
