### PR TITLE
Replace Node 16 with Node 21

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: [16.x, 18.x, 20.x]
+                node-version: [18.x, 20.x, 21.x]
 
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
Node 16 was End-of-Life on [11 Sep 2023](https://endoflife.date/nodejs).
