### PR TITLE
Fix spectron tests running locally

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,3 +1,4 @@
+import { log } from "console"; // https://stackoverflow.com/a/70768410
 const { app, BrowserWindow, ipcMain, Menu, dialog } = require('electron');
 const fs = require('fs-jetpack');
 const base64ImageToFile = require('base64image-to-file');
@@ -115,10 +116,10 @@ app.on('ready', () => {
             }
         })
             .then((name) => {
-                console.log(`Added Extension:  ${name}`);
+                log(`Added Extension:  ${name}`);
             })
             .catch((err) => {
-                console.log('An error occurred: ', err);
+                log('An error occurred: ', err);
             });
     }
 });

--- a/tests/spectron/__tests__/spectron.test.js
+++ b/tests/spectron/__tests__/spectron.test.js
@@ -23,9 +23,8 @@ const imageSnapshotOptions = {
 
 describe('App Tests', () => {
     beforeEach(() => {
-        jest.setTimeout(30000);
         return app.start();
-    });
+    }, 35000); // timeout (ms)
 
     afterEach(() => {
         if (app?.isRunning()) {

--- a/tests/spectron/__tests__/spectron.test.js
+++ b/tests/spectron/__tests__/spectron.test.js
@@ -28,7 +28,9 @@ describe('App Tests', () => {
     });
 
     afterEach(() => {
-        return app.stop();
+        if (app?.isRunning()) {
+            return app.stop();
+        }
     });
 
     it('Opens the main window and clicks around', async () => {

--- a/tests/spectron/__tests__/spectron.test.js
+++ b/tests/spectron/__tests__/spectron.test.js
@@ -8,7 +8,8 @@ expect.extend({ toMatchImageSnapshot });
 
 const app = new Application({
     path: electronPath,
-    args: [path.join(__dirname, '..', '..', '..')]
+    args: [path.join(__dirname, '..', '..', '..')],
+    chromeDriverArgs: ['remote-debugging-port=9222']
 });
 
 const LOAD_DELAY = 1200;


### PR DESCRIPTION
I'm not sure how the tests past on the CI runners, but running locally with `yarn run test` has been problematic with `spectron`.

There have been cascading errors, with dozens of windows launched.  This fixes most of them, but there are still a couple windows left open.

`FAIL  tests/spectron/__tests__/spectron.test.js` 

```
 ● App Tests › Opens the main window and clicks around

   Failed to create session.
   unknown error: Chrome failed to start: exited abnormally.
     (unknown error: DevToolsActivePort file doesn't exist)
```
```
     Application not running

       29 |
       30 |     afterEach(() => {
     > 31 |         return app.stop();
```

```  
 ● App Tests › Opens the main window and clicks around
   thrown: "Exceeded timeout of 5000 ms for a hook.
   Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."
       24 |
       25 | describe('App Tests', () => {
     > 26 |     beforeEach(() => {
```
